### PR TITLE
Support color values

### DIFF
--- a/test/fixtures/function.colors.css
+++ b/test/fixtures/function.colors.css
@@ -1,0 +1,4 @@
+.colorful {
+  border-color: ugly-border(rgba(203,10,200,0.3),#1D1F21,  hsl(320,50%,50%),hsla(230,90%,50%,0.7));
+}
+

--- a/test/fixtures/function.colors.nested.css
+++ b/test/fixtures/function.colors.nested.css
@@ -1,0 +1,4 @@
+.nested-color-calculation {
+  background-color: alpha(mix(#333, #FFF, 0.4), 0.8);
+}
+

--- a/test/fixtures/function.colors.nested.out.css
+++ b/test/fixtures/function.colors.nested.out.css
@@ -1,0 +1,4 @@
+.nested-color-calculation {
+  background-color: rgba(132, 132, 132, 0.8);
+}
+

--- a/test/fixtures/function.colors.out.css
+++ b/test/fixtures/function.colors.out.css
@@ -1,0 +1,4 @@
+.colorful {
+  border-color: rgba(203,10,200,0.3) #1D1F21 hsl(320,50%,50%) hsla(230,90%,50%,0.7);
+}
+


### PR DESCRIPTION
Color values didn't work because they can contain parenthesis, and this module doesn't handle parenthesis properly. I've hacked around it in the manor of the existing code.
Really, the code should be ~~refactored~~ rewritten to work more like [rework-vars](https://github.com/reworkcss/rework-vars/blob/master/index.js) and use [balanced-match](https://www.npmjs.com/package/balanced-match)

(I'll be moving to [postcss](https://github.com/postcss/postcss) now)
